### PR TITLE
Import order: Move @/ alias to the parent group

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ module.exports = {
       alphabetize: {
         order: 'asc'
       },
+      pathGroups: [{
+        pattern: '@/**',
+        group: 'parent'
+      }]
     }],
   },
   settings: {


### PR DESCRIPTION
This handles the `@/` alias by adding it to the "parent" group.

Previously, the import order didn't know what to do with the alias, so it put it at the bottom.

Now siblings will come under it:

❌
<img width="672" alt="Screenshot 2022-12-22 at 17 57 48" src="https://user-images.githubusercontent.com/5038459/209197003-65552bf4-8c9c-42fc-a5d0-633b69edb8dc.png">

✅
<img width="662" alt="Screenshot 2022-12-22 at 17 58 26" src="https://user-images.githubusercontent.com/5038459/209197057-19e301d4-bae5-495d-b347-cc3cf5338559.png">
