### PR TITLE
Add you don't need lodash or underscore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
     commit-message:
       prefix: "fix"
       prefix-development: "chore"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- lint-staged

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  '*.js': 'eslint --fix',
+  '*.{ts,tsx,js,jsx,yml,yaml,json}': 'eslint --fix',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@etchteam/eslint-config",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-plugin-storybook": "^0.6.15",
         "eslint-plugin-unused-imports": "^3.0.0",
         "eslint-plugin-yml": "^1.10.0",
+        "eslint-plugin-you-dont-need-lodash-underscore": "^6.14.0",
         "prettier": ">=3.0.0"
       },
       "devDependencies": {
@@ -2651,6 +2652,17 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-plugin-you-dont-need-lodash-underscore": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-you-dont-need-lodash-underscore/-/eslint-plugin-you-dont-need-lodash-underscore-6.14.0.tgz",
+      "integrity": "sha512-3zkkU/O1agczP7szJGHmisZJS/AknfVl6mb0Zqoc95dvFsdmfK+cbhrn+Ffy0UWB1pgDJwQr7kIO3rPstWs3Dw==",
+      "dependencies": {
+        "kebab-case": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/eslint-rule-composer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
@@ -3846,6 +3858,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kebab-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.2.tgz",
+      "integrity": "sha512-7n6wXq4gNgBELfDCpzKc+mRrZFs7D+wgfF5WRFLNAr4DA/qtr9Js8uOAVAfHhuLMfAcQ0pRKqbpjx+TcJVdE1Q=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -8025,6 +8042,14 @@
         "yaml-eslint-parser": "^1.2.1"
       }
     },
+    "eslint-plugin-you-dont-need-lodash-underscore": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-you-dont-need-lodash-underscore/-/eslint-plugin-you-dont-need-lodash-underscore-6.14.0.tgz",
+      "integrity": "sha512-3zkkU/O1agczP7szJGHmisZJS/AknfVl6mb0Zqoc95dvFsdmfK+cbhrn+Ffy0UWB1pgDJwQr7kIO3rPstWs3Dw==",
+      "requires": {
+        "kebab-case": "^1.0.0"
+      }
+    },
     "eslint-rule-composer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
@@ -8850,6 +8875,11 @@
         "object.assign": "^4.1.4",
         "object.values": "^1.1.6"
       }
+    },
+    "kebab-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.2.tgz",
+      "integrity": "sha512-7n6wXq4gNgBELfDCpzKc+mRrZFs7D+wgfF5WRFLNAr4DA/qtr9Js8uOAVAfHhuLMfAcQ0pRKqbpjx+TcJVdE1Q=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-storybook": "^0.6.15",
     "eslint-plugin-unused-imports": "^3.0.0",
     "eslint-plugin-yml": "^1.10.0",
+    "eslint-plugin-you-dont-need-lodash-underscore": "^6.14.0",
     "prettier": ">=3.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Etch's standard eslint config",
   "main": "src/index.js",
   "scripts": {
+    "postinstall": "husky install",
     "test": "echo \"Error: no test specified\" && exit 1",
     "release": "semantic-release"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:jsx-a11y/strict',
     'plugin:json/recommended',
+    'plugin:you-dont-need-lodash-underscore/compatible',
     'plugin:yml/standard',
     'plugin:yml/prettier',
   ],


### PR DESCRIPTION
Adds the [You don't need lodash/underscore](https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore) package, to ensure we make better use of native apis.

Also fixes the dependabot config, and does some devex improvements.

Closes ETCH-547