### PR TITLE
fix: add browser globals to webc virtual JS files

### DIFF
--- a/src/configs/webc.mjs
+++ b/src/configs/webc.mjs
@@ -1,3 +1,5 @@
+import globals from 'globals';
+
 import webcPlugin from '../plugins/webc-processor.mjs';
 
 /**
@@ -14,5 +16,11 @@ export default [
   {
     files: ['**/*.webc'],
     processor: webcPlugin.processors.webc,
+  },
+  {
+    files: ['**/*.webc/*.js'],
+    languageOptions: {
+      globals: globals.browser,
+    },
   },
 ];


### PR DESCRIPTION
## Summary

- Adds `globals.browser` to `**/*.webc/*.js` files in the WebC ESLint config
- WebC processor extracts inline `<script>` content into virtual `.js` files — without browser globals, ESLint flags false positives for `document`, `window`, etc.