### PR TITLE
Add eslint-plugin-sonarjs to base config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-plugin-json": "^4.0.1",
         "eslint-plugin-prettier": "^5.5.0",
         "eslint-plugin-security": "^4.0.0",
+        "eslint-plugin-sonarjs": "^3.0.7",
         "eslint-plugin-unused-imports": "^4.1.3",
         "eslint-plugin-yml": "^3.0.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.14.0",
@@ -2468,6 +2469,27 @@
         }
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -4340,6 +4362,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -4361,9 +4395,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6000,6 +6032,42 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.7.tgz",
+      "integrity": "sha512-62jB20krIPvcwBLAyG3VVKa2ce2j2lL1yCb8Y0ylMRR/dLvCCTiQx8gQbXb+G81k1alPZ2/I3muZinqWQdBbzw==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "4.12.2",
+        "builtin-modules": "3.3.0",
+        "bytes": "3.1.2",
+        "functional-red-black-tree": "1.0.1",
+        "jsx-ast-utils-x": "0.1.0",
+        "lodash.merge": "4.6.2",
+        "minimatch": "10.1.2",
+        "scslre": "0.3.0",
+        "semver": "7.7.4",
+        "typescript": ">=5"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-plugin-storybook": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.3.5.tgz",
@@ -6779,6 +6847,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT"
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -8043,6 +8117,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/kebab-case": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.2.tgz",
@@ -8216,8 +8299,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -9730,6 +9812,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -9757,6 +9851,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/regexp-tree": {
@@ -10035,6 +10142,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -10968,7 +11089,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-json": "^4.0.1",
     "eslint-plugin-prettier": "^5.5.0",
     "eslint-plugin-security": "^4.0.0",
+    "eslint-plugin-sonarjs": "^3.0.7",
     "eslint-plugin-unused-imports": "^4.1.3",
     "eslint-plugin-yml": "^3.0.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.14.0",
@@ -77,8 +78,8 @@
     "eslint-plugin-jsx-a11y": ">=6.0.0",
     "eslint-plugin-lit": ">=2.0.0",
     "eslint-plugin-react": ">=7.0.0",
-    "eslint-plugin-storybook": ">=10.0.0",
     "eslint-plugin-react-hooks": ">=5.0.0",
+    "eslint-plugin-storybook": ">=10.0.0",
     "prettier": ">=3.0.0",
     "typescript": ">=4.8.4"
   },

--- a/src/base.mjs
+++ b/src/base.mjs
@@ -2,11 +2,36 @@ import js from '@eslint/js';
 import importPlugin from 'eslint-plugin-import';
 import prettier from 'eslint-plugin-prettier/recommended';
 import security from 'eslint-plugin-security';
+import sonarjs from 'eslint-plugin-sonarjs';
 import unusedImports from 'eslint-plugin-unused-imports';
 import youDontNeedLodash from 'eslint-plugin-you-dont-need-lodash-underscore';
 import tseslint from 'typescript-eslint';
 
 import { fixupPluginRules } from './utils/fixup.mjs';
+
+const JS_FILES = ['**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'];
+
+/**
+ * Catch some common sonar issues locally, this is JS/TS only and not a 1:1 mirror
+ * of Sonar's web-UI Quality Profile. Everything is downgraded to 'warn' because it
+ * doesn't recognise when issues have been marked as safe in the Sonar web UI.
+ *
+ * Rule updates:
+ * - `file-header` is off because we never us a header template and it warns on every file.
+ * - `sonarjs/arrow-function-convention` is off because it conflicts with prettier.
+ */
+const sonarConfig = {
+  ...sonarjs.configs.recommended,
+  files: JS_FILES,
+  rules: {
+    ...Object.fromEntries(
+      Object.keys(sonarjs.configs.recommended.rules).map((r) => [r, 'warn']),
+    ),
+    'sonarjs/file-header': 'off',
+    'sonarjs/arrow-function-convention': 'off',
+    'sonarjs/declarations-in-global-scope': 'off',
+  },
+};
 
 /**
  * Base ESLint configuration for all projects.
@@ -17,8 +42,9 @@ export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
   security.configs.recommended,
+  sonarConfig,
   {
-    files: ['**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+    files: JS_FILES,
     plugins: {
       'unused-imports': unusedImports,
       import: fixupPluginRules(importPlugin),


### PR DESCRIPTION
## Summary
- Add `eslint-plugin-sonarjs` to the base config so Sonar's JS/TS rules surface in the IDE and pre-commit instead of after PR creation.
- All rules set to `warn` — the plugin can't read "won't fix" flags from the Sonar web UI, so warnings avoid blocking commits/CI while still showing as squiggles.
- Scoped to JS/TS (`JS_FILES`) to avoid crashes on YAML/JSON source models.
- Disabled: `file-header` (no header template), `arrow-function-convention` (conflicts with prettier), `declarations-in-global-scope` (false positives in ESM/TS modules).

## Test plan
- [x] `npx eslint src` passes with 0 errors (warnings only)
- [x] `npx eslint test-files/` still produces expected violations (CI sanity check)
- [x] Verified sonarjs fires on JS/TS and does not crash on YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)