### PR TITLE
Add dot-notation, no-implicit-coercion, and Number.* global rules

### DIFF
--- a/src/base.mjs
+++ b/src/base.mjs
@@ -85,6 +85,19 @@ export default [
       'security/detect-object-injection': 'off',
       'spaced-comment': 'error',
       curly: 'error',
+      'dot-notation': 'warn',
+      'no-implicit-coercion': 'error',
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'parseInt',
+          message: 'Use Number.parseInt instead.',
+        },
+        {
+          name: 'parseFloat',
+          message: 'Use Number.parseFloat instead.',
+        },
+      ],
     },
     settings: {
       'import/resolver': {

--- a/test-files/test.js
+++ b/test-files/test.js
@@ -7,6 +7,18 @@ import { useState } from 'react';
 // Test unused variables
 const unusedVar = 'test';
 
+// Test dot-notation (should be caught)
+const obj = { foo: 1 };
+const viaBracket = obj['foo'];
+
+// Test no-restricted-globals for parseInt/parseFloat (should be caught)
+const int = parseInt('42', 10);
+const float = parseFloat('3.14');
+
+// Test no-implicit-coercion (should be caught)
+const asBool = !!viaBracket;
+const asNum = +int;
+
 // Test React component with accessibility and other rules
 const TestComponent = () => {
   const [count, setCount] = useState(0);


### PR DESCRIPTION
- Add `dot-notation` as a warning to signal preference for `obj.prop` over `obj['prop']` without blocking cases where bracket access is needed.
- Add `no-implicit-coercion` as an error so `!!value` and `+value` must be written as `Boolean(value)` / `Number(value)`.
- Add `no-restricted-globals` entries for `parseInt` and `parseFloat` so projects use `Number.parseInt` / `Number.parseFloat` instead.
- Extend `test-files/test.js` with fixtures that trigger each new rule to keep CI validation honest.